### PR TITLE
Fix data dictionary compiling error

### DIFF
--- a/FlikeMiddleware.swift
+++ b/FlikeMiddleware.swift
@@ -9,10 +9,14 @@ import Foundation
 import Amplitude
 
 
-// convertyPayload converts Middleware Payload (event,extra) into JSON Dictionary Data
-func convertPayload(event: NSMutableDictionary,extra: NSMutableDictionary?) -> Data {
+// convertPayload converts Middleware Payload (event, extra) into JSON Dictionary Data
+func convertPayload(event: NSMutableDictionary, extra: NSMutableDictionary?) -> Data {
     // convert to JSON ....
-    var data: [String: NSMutableDictionary]
+    var data: [String: NSMutableDictionary] = ["event": event]
+    if let extra = extra {
+        data["extra"] = extra
+    }
+    
     guard let jsonData = try? JSONSerialization.data(withJSONObject: data, options: []) else {
         print("[FLIKE] Error when converting JSON")
         return Data()


### PR DESCRIPTION
Hello!

`convertPayload` method in `FlikeMiddleware.swift` causes a compiler error (look at screenshot). I fixed this error by init `data` dictionary with the necessary keys and values

<img width="1118" alt="Screenshot 2022-09-27 at 14 38 18" src="https://user-images.githubusercontent.com/29862757/192515579-592cb9c1-f2b5-45d1-ab34-d9f3df68c11c.png">
